### PR TITLE
feat: add themed 404 NotFound page

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -11,6 +11,7 @@ import HomePage from './pages/Home';
 import AboutPage from './pages/AboutPage';
 import DocumentationPage from './pages/DocumentationPage';
 import ContributorsPage from './pages/ContributorsPage';
+import NotFoundPage from './pages/NotFoundPage';
 import './App.css';
 
 function App() {
@@ -96,6 +97,10 @@ function App() {
             <Route 
               path="/contributors" 
               element={<ContributorsPage theme={theme} />} 
+            />
+            <Route 
+              path="*" 
+              element={<NotFoundPage theme={theme} />} 
             />
           </Routes>
         </Layout>

--- a/frontend/src/pages/NotFoundPage.jsx
+++ b/frontend/src/pages/NotFoundPage.jsx
@@ -1,0 +1,58 @@
+import { Link } from "react-router-dom";
+import { Code, AlertCircle, Cpu, ArrowLeft } from "lucide-react";
+
+const NotFoundPage = ({ theme }) => {
+  const isDark = theme === "dark";
+
+  return (
+    <div
+      className={`relative flex-1 flex flex-col items-center justify-center p-6 transition-all duration-500 ${
+        isDark
+          ? "bg-gradient-to-br from-gray-900 via-blue-900 to-purple-900 text-white"
+          : "bg-gradient-to-br from-blue-50 via-purple-50 to-pink-50 text-gray-900"
+      }`}
+    >
+      {/* Floating icons for tech vibe */}
+      <div className="absolute top-20 left-10 opacity-40 animate-bounce-slow">
+        <Code
+          className={`${isDark ? "text-white" : "text-gray-600"} w-16 h-16`}
+        />
+      </div>
+      <div className="absolute bottom-24 right-16 opacity-40 animate-spin-slow">
+        <Cpu
+          className={`${isDark ? "text-white" : "text-gray-600"} w-20 h-20`}
+        />
+      </div>
+      <div className="absolute top-40 right-20 opacity-40 animate-pulse-slow">
+        <AlertCircle
+          className={`${isDark ? "text-white" : "text-gray-600"} w-12 h-12`}
+        />
+      </div>
+
+      {/* Main content */}
+      <div className="relative z-10 text-center max-w-xl">
+        <h1 className="text-7xl font-extrabold mb-4 animate-pulse">404</h1>
+        <p className="text-2xl mb-6">
+          Uh-oh! This algorithm didn't find a solution here.
+        </p>
+        <p className="text-lg mb-8">
+          Looks like this page isn't in the visualization. Try going back and
+          exploring!
+        </p>
+        <Link
+          to="/"
+          className={`inline-flex items-center gap-2 px-6 py-4 rounded-lg font-semibold shadow-lg transition-transform transform hover:scale-105 ${
+            isDark
+              ? "bg-blue-600 hover:bg-blue-700 text-white"
+              : "bg-blue-500 hover:bg-blue-600 text-white"
+          }`}
+        >
+          <ArrowLeft className="w-5 h-5" />
+          Go Back to Visualizer
+        </Link>
+      </div>
+    </div>
+  );
+};
+
+export default NotFoundPage;

--- a/frontend/src/pages/NotFoundPage.jsx
+++ b/frontend/src/pages/NotFoundPage.jsx
@@ -1,5 +1,5 @@
 import { Link } from "react-router-dom";
-import { Code, AlertCircle, Cpu, ArrowLeft } from "lucide-react";
+import { AlertCircle, Cpu, ArrowLeft } from "lucide-react";
 
 const NotFoundPage = ({ theme }) => {
   const isDark = theme === "dark";
@@ -14,18 +14,13 @@ const NotFoundPage = ({ theme }) => {
     >
       {/* Floating icons for tech vibe */}
       <div className="absolute top-20 left-10 opacity-40 animate-bounce-slow">
-        <Code
-          className={`${isDark ? "text-white" : "text-gray-600"} w-16 h-16`}
-        />
-      </div>
-      <div className="absolute bottom-24 right-16 opacity-40 animate-spin-slow">
-        <Cpu
-          className={`${isDark ? "text-white" : "text-gray-600"} w-20 h-20`}
-        />
-      </div>
-      <div className="absolute top-40 right-20 opacity-40 animate-pulse-slow">
         <AlertCircle
           className={`${isDark ? "text-white" : "text-gray-600"} w-12 h-12`}
+        />
+      </div>
+      <div className="absolute bottom-20 right-32 opacity-40 animate-spin-slow">
+        <Cpu
+          className={`${isDark ? "text-white" : "text-gray-600"} w-20 h-20`}
         />
       </div>
 


### PR DESCRIPTION
# Feature: Themed 404 NotFound Page

## Description
This PR adds a fully designed **404 NotFound page** to improve user experience when navigating to non-existent routes.  
The page is themed to match the **Algorithm Visualizer** aesthetics and supports both **dark and light modes**.

## Features
- Full-page 404 with dark/light mode gradient backgrounds.
- Fun, programming-related quotes to keep the theme playful.
- Lucide icons (`Code`, `Cpu`, `AlertCircle`) floating in the background with subtle animations.
- Centered content with a responsive, styled **"Go Back to Visualizer"** button including an arrow icon.
- Icons are properly visible in both dark and light themes.
- Layout adjusted to respect wrapper padding (`pt-20`) without causing overflow.

## Screenshots
<img width="1295" height="650" alt="image" src="https://github.com/user-attachments/assets/bef81034-517e-454d-a7cf-45584129138d" />


## How to Test
1. Run the application locally.
2. Navigate to a non-existent route, e.g., `/non-existing-page`.
3. Verify that the 404 page displays correctly in both dark and light modes.
4. Check that the "Go Back to Visualizer" button works and links back to `/`.

