### PR TITLE
add color attribute to GraphNode and GraphEdge

### DIFF
--- a/cpp/include/models/graph_models.h
+++ b/cpp/include/models/graph_models.h
@@ -7,17 +7,21 @@ struct GraphNode {
     int id;
     std::string label;
     double x, y;
-    
-    GraphNode(int id, const std::string& label = "", double x = 0.0, double y = 0.0);
+    std::string color;
+
+    GraphNode(int id, const std::string& label = "", double x = 0.0, double y = 0.0, const std::string& color = "white");
 };
+
 
 struct GraphEdge {
     int from, to;
     double weight;
     bool directed;
-    
-    GraphEdge(int from, int to, double weight = 1.0, bool directed = false);
+    std::string color;
+
+    GraphEdge(int from, int to, double weight = 1.0, bool directed = false, const std::string& color = "black");
 };
+
 
 struct GraphStep {
     std::vector<int> visitedNodes;

--- a/cpp/src/models/graph_models.cpp
+++ b/cpp/src/models/graph_models.cpp
@@ -1,10 +1,10 @@
 #include "models/graph_models.h"
 
-GraphNode::GraphNode(int id, const std::string& label, double x, double y)
-    : id(id), label(label), x(x), y(y) {}
+GraphNode::GraphNode(int id, const std::string& label, double x, double y, const std::string& color)
+    : id(id), label(label), x(x), y(y), color(color) {}
 
-GraphEdge::GraphEdge(int from, int to, double weight, bool directed)
-    : from(from), to(to), weight(weight), directed(directed) {}
+GraphEdge::GraphEdge(int from, int to, double weight, bool directed, const std::string& color)
+    : from(from), to(to), weight(weight), directed(directed), color(color) {}
 
 GraphStep::GraphStep(const std::string& operation)
     : operation(operation) {}


### PR DESCRIPTION
### Overview
This PR adds a `color` attribute to the `GraphNode` and `GraphEdge` structs in the graph models. The color attribute will allow the frontend to visually highlight nodes and edges during algorithm visualizations, improving the clarity and interactivity of the visualizations.

### Changes
- Added `std::string color` to `GraphNode` and `GraphEdge`.
- Updated constructors to accept an optional color parameter with default values:
  - Nodes: "white"
  - Edges: "black"
- Updated `graph_model.cpp` to initialize the new color fields.

Fixes #19 